### PR TITLE
Rename CSS selectors to match module name

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,8 +1,8 @@
-.gurps-birosca {
+.gurps-instant-bazaar {
   font-family: 'Signika', sans-serif;
 }
 
-.gurps-birosca .window-content {
+.gurps-instant-bazaar .window-content {
   padding: 1rem;
 }
 


### PR DESCRIPTION
## Summary
- Replace .gurps-birosca selectors with .gurps-instant-bazaar in styles.css

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8fa1aed1c832c9f8434aea51a01c1