### PR TITLE
Atualiza manifesto e compatibilidade para Foundry V13

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Donate](https://img.shields.io/badge/Donate-Sponsor%20on%20GitHub-black?logo=github)](https://github.com/sponsors/Boifuba)
 
-# Vendor & Wallet System
+# GURPS Instant Bazaar
 
 A comprehensive FoundryVTT module that provides a complete vendor and wallet management system for Game Masters and players.
 
@@ -48,7 +48,7 @@ The Vendor & Wallet System transforms your FoundryVTT game by adding a complete 
 
 - **Use this manifest**
 
-https://raw.githubusercontent.com/Boifuba/gurps-birosca/refs/heads/main/module.json
+https://raw.githubusercontent.com/Boifuba/gurps-instant-bazaar/refs/heads/main/module.json
 
 ## Quick Start Guide
 
@@ -230,7 +230,7 @@ Fine-tune your vendor inventories by editing individual items:
 ## Technical Information
 
 ### System Requirements
-- FoundryVTT v11 or higher
+- FoundryVTT v13 or higher
 - Compatible with most game systems
 - Requires GM permissions for vendor management
 
@@ -274,7 +274,7 @@ We welcome suggestions for new features! Consider:
 ---
 
 **Version**: 1.0.0  
-**Compatibility**: FoundryVTT v11+  
+**Compatibility**: FoundryVTT v13+  
 **Author**: GM Tools  
 
 *Happy gaming! 🎲*

--- a/module.json
+++ b/module.json
@@ -27,7 +27,7 @@
     "styles.css"
   ],
   "socket": true,
-  "manifest": "https://raw.githubusercontent.com/Boifuba/gurps-birosca/refs/heads/main/module.json",
+  "manifest": "https://raw.githubusercontent.com/Boifuba/gurps-instant-bazaar/refs/heads/main/module.json",
   "download": "https://github.com/Boifuba/gurps-birosca/releases/download/alpha/gurps-birosca.zip"
 
 }


### PR DESCRIPTION
## Summary
- Update README header and manifest link
- Require FoundryVTT v13 or later and document compatibility
- Point manifest file to new repository location

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8fa1ba0c4832c9489cf566303e8a7