### PR TITLE
Localize currency formatting and simplify parse logic

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1,0 +1,3 @@
+{
+  "GURPS.InstantBazaar.CurrencySymbol": "$"
+}

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1,0 +1,3 @@
+{
+  "GURPS.InstantBazaar.CurrencySymbol": "$"
+}

--- a/main.js
+++ b/main.js
@@ -22,10 +22,8 @@ class VendorWalletSystem {
    * @returns {string} Formatted currency string
    */
   static formatCurrency(amount) {
-    return '$' + Number(amount || 0).toLocaleString(undefined, {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2
-    });
+    const symbol = game.i18n?.localize('GURPS.InstantBazaar.CurrencySymbol') ?? '$';
+    return symbol + String(amount ?? 0);
   }
 
   /**
@@ -36,7 +34,9 @@ class VendorWalletSystem {
   static parseCurrency(value) {
     if (typeof value === 'number') return value;
     if (typeof value === 'string') {
-      return Number(value.replace(/[^0-9.-]+/g, '')) || 0;
+      const cleaned = value.replace(/[^0-9.-]/g, '');
+      const parsed = cleaned === '' ? 0 : Number(cleaned);
+      return isNaN(parsed) ? 0 : parsed;
     }
     return 0;
   }

--- a/module.json
+++ b/module.json
@@ -27,6 +27,10 @@
   "styles": [
     "styles.css"
   ],
+  "languages": [
+    { "lang": "en", "name": "English", "path": "lang/en.json" },
+    { "lang": "pt-BR", "name": "Português (Brasil)", "path": "lang/pt-BR.json" }
+  ],
   "socket": true,
   "manifest": "https://raw.githubusercontent.com/Boifuba/gurps-instant-bazaar/refs/heads/main/module.json",
 


### PR DESCRIPTION
## Summary
- Localize `VendorWalletSystem.formatCurrency` using a translatable currency symbol and basic string conversion
- Ensure `parseCurrency` safely handles integers without decimals
- Register language files for English and Portuguese

## Testing
- `npm test` (fails: ENOENT, package.json not found)

------
https://chatgpt.com/codex/tasks/task_e_68bace360bdc832cb612db764c7985f8