### PR TITLE
fix: correct sponsor badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ We welcome suggestions for new features! Consider:
 
 <p align="center">
   <a href="https://github.com/sponsors/Boifuba">
-    <img src="https://img.shields.io/badge/Sponsor-30363D?style=for-the-badge&logo=GitHub-Sponsors&logoColor=#white)](https://github.com/sponsors/Boifuba" width="200" alt="Apoie este projeto"/>
+    <img src="https://img.shields.io/badge/Sponsor-30363D?style=for-the-badge&logo=GitHub-Sponsors&logoColor=white" width="200" alt="Apoie este projeto"/>
   </a>
 </p>
 


### PR DESCRIPTION
## Summary
- fix sponsor badge image URL and anchor link in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe79fcf24832c81b4f8902990e406