### PR TITLE
Atualizar documentação das aplicações Handlebars

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -486,18 +486,16 @@ Defines the `VendorWalletSystem` static controller.
 /**
  * Menu of GM utilities.
  * @class GMToolsApplication
- * @extends Application
+ * @extends {foundry.applications.api.HandlebarsApplicationMixin}
  */
 ```
 
 ```javascript
 /**
- * Bind button events on render.
+ * Set up event listeners after rendering.
  * @method GMToolsApplication#_onRender
- * @param {Application} app - Application instance.
- * @param {jQuery} html - Rendered HTML.
  * @returns {void}
- */
+*/
 ```
 
 ```javascript
@@ -519,7 +517,7 @@ Defines the `VendorWalletSystem` static controller.
 /**
  * GM interface for adjusting player funds.
  * @class MoneyManagementApplication
- * @extends Application
+ * @extends {foundry.applications.api.HandlebarsApplicationMixin}
  */
 ```
 
@@ -558,7 +556,7 @@ Defines the `VendorWalletSystem` static controller.
 /**
  * Wizard to create vendors with random items.
  * @class VendorCreationApplication
- * @extends Application
+ * @extends {foundry.applications.api.HandlebarsApplicationMixin}
  */
 ```
 
@@ -641,7 +639,7 @@ Defines the `VendorWalletSystem` static controller.
 /**
  * Overview window listing all vendors.
  * @class VendorManagerApplication
- * @extends Application
+ * @extends {foundry.applications.api.HandlebarsApplicationMixin}
  */
 ```
 
@@ -698,7 +696,7 @@ Defines the `VendorWalletSystem` static controller.
 /**
  * Editor for a single vendor.
  * @class VendorEditApplication
- * @extends Application
+ * @extends {foundry.applications.api.HandlebarsApplicationMixin}
  */
 ```
 
@@ -790,7 +788,7 @@ Defines the `VendorWalletSystem` static controller.
 /**
  * Editor for an individual vendor item.
  * @class VendorItemEditApplication
- * @extends Application
+ * @extends {foundry.applications.api.HandlebarsApplicationMixin}
  */
 ```
 
@@ -856,7 +854,7 @@ Defines the `VendorWalletSystem` static controller.
 /**
  * Combined wallet viewer and vendor browser for players.
  * @class PlayerWalletApplication
- * @extends Application
+ * @extends {foundry.applications.api.HandlebarsApplicationMixin}
  * @param {object} [options] - Application options.
  */
 ```
@@ -897,7 +895,7 @@ Defines the `VendorWalletSystem` static controller.
 /**
  * Stand‑alone window showing a vendor's inventory.
  * @class VendorDisplayApplication
- * @extends Application
+ * @extends {foundry.applications.api.HandlebarsApplicationMixin}
  * @param {object} [options] - Application options.
  */
 ```
@@ -912,10 +910,27 @@ Defines the `VendorWalletSystem` static controller.
 
 ```javascript
 /**
- * Handle purchase button actions.
- * @method VendorDisplayApplication#_onPurchaseAction
+ * Set up event listeners after rendering.
+ * @method VendorDisplayApplication#_onRender
+ * @returns {void}
+ */
+```
+
+```javascript
+/**
+ * Handle item purchase clicks.
+ * @method VendorDisplayApplication#_onPurchaseItem
  * @param {MouseEvent} event - Click event.
  * @returns {Promise<void>}
+ */
+```
+
+```javascript
+/**
+ * Refresh open displays for a specific vendor.
+ * @function VendorDisplayApplication.refreshDisplays
+ * @param {string} vendorId - Vendor identifier.
+ * @returns {void}
  */
 ```
 
@@ -929,7 +944,7 @@ Defines the `VendorWalletSystem` static controller.
 /**
  * Configure coin denominations and behavior.
  * @class CurrencySettingsApplication
- * @extends Application
+ * @extends {foundry.applications.api.HandlebarsApplicationMixin}
  */
 ```
 


### PR DESCRIPTION
## Summary
- Ajustar CODEBASE.md para usar `HandlebarsApplicationMixin` nos apps
- Atualizar documentação do VendorDisplayApplication com novos métodos

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be09c7a520832caac68f438cad5176